### PR TITLE
Rutor single thread ARM processors defect fix

### DIFF
--- a/resources/site-packages/xbmctorrent/scrapers/rutor.py
+++ b/resources/site-packages/xbmctorrent/scrapers/rutor.py
@@ -117,7 +117,7 @@ def rutor_page(catind, page, query = None):
     from contextlib import closing
     from itertools import izip
     from concurrent import futures
-    from multiprocessing.pool import ThreadPool
+    # from multiprocessing.pool import ThreadPool
     from xbmctorrent.utils import terminating, SafeDialogProgress
 
     scraper_name = ""
@@ -201,12 +201,14 @@ def rutor_page(catind, page, query = None):
                 line2 = data["info"].get("title") or data.get("label") or "",
             )
 
-        with terminating(ThreadPool(5)) as pool: 
-            jobs = [pool.apply_async(_get_torrent_info, [item], callback=on_done) for item in items]
-            while not all(job.ready() for job in jobs):
-                if dialog.iscanceled():
-                    return
-                xbmc.sleep(100)
+        # Turn off multitask to avoid error on arm and python26, use signle process instead
+        # with terminating(ThreadPool(5)) as pool: 
+        #     jobs = [pool.apply_async(_get_torrent_info, [item], callback=on_done) for item in items]
+        #     while not all(job.ready() for job in jobs):
+        #         if dialog.iscanceled():
+        #             return
+        #         xbmc.sleep(100)
+        jobs = [_get_torrent_info(item) for item in items]
 
         import hashlib
 


### PR DESCRIPTION
On ARM processors, I use fire tv. Error occired when rutor scrapper used. Error message report that no _multiprocessing module. To avoid this problem, i do refactor to use single thread. For future some wrapper should be written which will detect if multiprocessing is supported.

i am not expert in git and github, only changes from rutor.py files should e applied.
